### PR TITLE
Harden Colander Shadownet RPC reads

### DIFF
--- a/.agents/docs/live/BUG_BOUNTY_BOARD.md
+++ b/.agents/docs/live/BUG_BOUNTY_BOARD.md
@@ -68,6 +68,7 @@ Priority labels:
 | WTF-BB-344 | Verified | Codex Pasta live verification docs | 2026-07-01 | Pasta Protocol / installer catalog | P2 | 9 | 12 | 1 | 3 | 2 | Unified "suite or any individual Pasta app" catalogue is deployed on live `wtfos.app` and reconfirmed on commit `26c60cd`: `/api/pasta/installers/catalog` returns unauthenticated `401`, `PASTA_LIVE_READINESS_ALLOW_BLOCKERS=1 npm run pasta:live-readiness` passes the catalog probe, and the gate verifies Macaroni, Pasta Suite, Spaghetti, Gnocchi, Ravioli, Rotini, Penne, and Lasagna public release assets while still blocking only on missing WTF.ME publish credentials and live Pasta host proof |
 | WTF-BB-345 | Verified | Codex Inbox compose full-send | 2026-07-01 | Social / Inbox and WIM compose UX | P1 | 12 | 7 | 3 | 5 | 0 | Inbox aggregated mail, WIM, Studio, comms, and notifications but still behaved like a read-only viewer; current branch adds first-class New message/New mail controls, selected external-mail Reply/Forward actions, inline WIM/Studio conversation sending through source-owned DM APIs, inventory-owned behavior assertions, admin registry coverage, and verified clean-worktree source, build, focused browser, and full inventory coverage before production promotion |
 | WTF-BB-346 | Fixed | Codex WTF LIVE smart-room goal | 2026-07-01 | WTF LIVE / user-aware room operations | P1 | 14 | 3 | 4 | 5 | 1 | WTF LIVE now has user-aware owner role/invite controls, owner room/stage scheduling to WTF/TTC targets, persisted room settings, and saved Show Kits that can be associated with public rooms, private rooms, and stages; verified with TypeScript, build, inventory coverage, focused WTF LIVE Playwright, and full inventory E2E |
+| WTF-BB-347 | Fixed | Codex Pasta Colander RPC fallback | 2026-07-01 | Pasta Protocol / Colander Shadownet RPC resilience | P1 | 11 | 8 | 2 | 4 | 1 | Colander Shadownet discovery now retries recoverable primary RPC timeouts through the configured `https://tcinfra.net/rpc/tezos/shadownet` fallback with a bounded per-attempt read budget while preserving explicit env RPC overrides and the localhost wallet harness; focused, full Colander, and warm-prefix inventory proofs pass |
 | WTF-BB-324 | Verified | Codex Gamma shell continuation | 2026-06-30 | E2E / Gamma Swap harness wallet state | P2 | 8 | 14 | 2 | 3 | 0 | Gamma Swap proof now seeds the accepted Octez wallet session provider (`octez.connect`) instead of stale Beacon state; verified by focused source policy, focused Gamma Swap Playwright, and full Gamma suite `62/62` on `HARNESS_PORT=4307` |
 | WTF-BB-323 | Verified | Codex Pasta live-readiness | 2026-06-30 | E2E / WTF Domains Settings applet wallet prefill | P2 | 8 | 14 | 2 | 3 | 0 | Settings Subdomain Setup and cobwebsaints inventory specs now seed the accepted Octez wallet session provider instead of stale Beacon state; verified by focused fresh-harness proof plus branch/main Quality Gates through `28467035060` |
 | WTF-BB-322 | Open | - | 2026-06-29 | Desktop OS / Recovery Mode route smoke | P2 | 9 | 12 | 2 | 3 | 1 | Full inventory route smoke for `/recovery-mode` fails because a 401 Unauthorized console error is treated as fatal browser noise; decide whether the route should avoid the protected probe or the inventory harness should classify the expected auth check as non-fatal |
@@ -6169,7 +6170,7 @@ Priority labels:
 ### WTF-BB-272 - Macaroni social shares omit creator social identity and token media
 
 - Category: Macaroni / generated drop website social sharing
-- Status: In Progress
+- Status: Fixed
 - Owner/Session: Codex Macaroni social-share identity/media pass
 - Score: C2 + F4 + S0 + P1(4) = 10
 - Evidence:
@@ -7409,6 +7410,35 @@ Priority labels:
   - Confirmed the closest existing production host still fails correctly: `PASTA_WTFME_LIVE_HOST=paulwhoisaghost.wtfos.me PASTA_WTFME_LIVE_CHECK_PINS=0 npm run pasta:wtfme:live-check` exits on the missing Pasta landing marker.
   - Passed `git diff --check`.
   - Still blocked live: no production host currently serves the Pasta landing/mint/collection pages plus public pin discovery; `wtf-admin.wtfos.me` is unregistered, and `paulwhoisaghost.wtfos.me` is registered but not yet published with Pasta content.
+
+### WTF-BB-347 - Colander Shadownet discovery needs RPC fallback
+
+- Category: Pasta Protocol / Colander Shadownet RPC resilience
+- Status: In Progress
+- Owner/Session: Codex Pasta Colander RPC fallback
+- Score: C2 + F4 + S1 + P1(4) = 11
+- Evidence:
+  - Main Quality Gates run `28548649768` failed the Inventory Playwright smoke on `tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs` while waiting for a proven Shadownet contract fact row.
+  - Local focused reproduction with `HARNESS_PORT=4322 npx playwright test tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs -g "opens proven Shadownet" --project=chromium --reporter=list` failed after opening earlier contracts and rendering `HTTP request timeout of 30000ms exceeded` for Rotini.
+  - The failure moved between CI and local runs, proving a single bad contract expectation was not the root cause. Colander used the primary `https://tezos-shadownet.octez.io/` endpoint without the configured Shadownet fallback.
+  - A broad inventory reproduction after adding fallback still failed while the page was stuck in `Reading ...` state: the first RPC attempt could spend Taquito's full 30s timeout before fallback, leaving the 45s assertion window too tight.
+- Why it matters:
+  - Colander is the Pasta ownership/discovery control panel. A transient primary RPC timeout should not make the live app or release gate fail when the project has an explicit fallback endpoint for Shadownet.
+- Correction direction:
+  - Add shared client fallback metadata for configured Tezos RPCs.
+  - Route Colander read-only contract discovery through a recoverable-error fallback helper with a bounded per-attempt timeout while preserving explicit user/env RPC overrides and the localhost test harness.
+- Verification idea:
+  - Focused Colander discovery Playwright proof passes after fallback support.
+  - Policy coverage proves the Shadownet fallback remains wired into the shared client Tezos helpers and Colander.
+  - Main Quality Gates are rerun or a branch Quality Gates run proves the full inventory smoke.
+- Current pass verification:
+  - Passed `npx tsx --test client/src/lib/tezos/wallet-shadownet-preflight-policy.test.ts client/src/lib/tezos/wallet-connect-policy.test.ts`.
+  - Passed `npm run check -- --pretty false`.
+  - Passed `npm run build && HARNESS_PORT=4322 npx playwright test tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs -g "opens proven Shadownet" --project=chromium --reporter=list`; the previously failing read-only discovery proof opened all six proven Shadownet contracts.
+  - Passed `HARNESS_PORT=4322 npx playwright test tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs --project=chromium --reporter=list`; the localhost browser-wallet action harness still passes.
+  - Passed warm-prefix inventory reproduction after the bounded-attempt fix: `npx playwright test tests/playwright/inventory/auth-session.spec.mjs tests/playwright/inventory/beta-wtfos.spec.mjs tests/playwright/inventory/broot.spec.mjs tests/playwright/inventory/cobwebsaints-account.spec.mjs tests/playwright/inventory/dedrooms.spec.mjs tests/playwright/inventory/desktop-settings-typography.spec.mjs tests/playwright/inventory/domain-interoperability.spec.mjs tests/playwright/inventory/feature-depth.spec.mjs tests/playwright/inventory/gamma-wtfos.spec.mjs tests/playwright/inventory/ipfs-pinning-manager.spec.mjs tests/playwright/inventory/macaroni-packager.spec.mjs tests/playwright/inventory/map-lab-workspace.spec.mjs tests/playwright/inventory/market-pricing.spec.mjs tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs --project=chromium --reporter=list` (`218 passed`).
+  - Passed `npm run test:e2e:inventory:coverage`, `npm run pasta:repo-cleanup:audit:check`, `npm run pasta:live-readiness:check`, `npm run pasta:repo-cleanup:audit`, `PASTA_LIVE_READINESS_ALLOW_BLOCKERS=1 npm run pasta:live-readiness`, and `git diff --check`.
+  - Pending remote verification: branch/main Quality Gates have not yet run for this fix.
 
 ### WTF-BB-343 - Remaining standalone Pasta installers are not all live
 

--- a/.agents/docs/live/LESSONS_LEARNED.md
+++ b/.agents/docs/live/LESSONS_LEARNED.md
@@ -1,3 +1,13 @@
+## 2026-07-01 - Browser chain proofs need configured RPC fallback
+
+**What happened**: Main Quality Gates failed the Colander Shadownet discovery smoke while waiting for a proven Pasta contract fact row. Local focused reproduction failed on a different proven contract and the page status showed `HTTP request timeout of 30000ms exceeded`, proving the root cause was a transient primary Shadownet RPC timeout, not a bad selector or stale KT1 fixture. A second broad-suite reproduction showed that fallback alone was still too slow when the first RPC attempt consumed Taquito's full 30s timeout.
+
+**Why it mattered**: Colander is the Pasta ownership/discovery control panel. A browser proof that relies on a single public RPC can fail a live promotion even when the project has an explicit fallback endpoint and the contracts are otherwise readable.
+
+**Rule**: Browser Tezos reads that use project default RPCs must route recoverable network/RPC failures through the configured fallback endpoint with a bounded per-attempt read budget. Preserve explicit user/env RPC overrides, keep wallet-signing preflights strict, and reproduce timeout failures before changing selectors or waits.
+
+---
+
 ## 2026-07-01 - Markdown backticks in shell arguments execute in zsh
 
 **What happened**: A `gh pr create --body "..."` command included a Markdown inline-code phrase using backticks around `pasta:live-readiness`. zsh treated the backticked phrase as command substitution, printed `command not found: pasta:live-readiness`, and created the PR with that phrase missing from the body.

--- a/client/src/features/pasta-protocol/colander/ColanderApp.tsx
+++ b/client/src/features/pasta-protocol/colander/ColanderApp.tsx
@@ -13,7 +13,7 @@ import styled from "styled-components";
 import { AppWindow } from "../../../components/layout/AppWindow";
 import { MOBILE } from "../../../global-styles";
 import { presentationRouteHref, usePresentationShell } from "../../../lib/presentation-shell";
-import { connectWallet, getActiveAccount, getTezos } from "../../../lib/tezos/wallet";
+import { connectWallet, getActiveAccount, getTezos, withTezosRpcFallback } from "../../../lib/tezos/wallet";
 import { getNetwork } from "../../../lib/tezos/loaders";
 import { assertNetworkReadyForSend } from "../../../lib/tezos/preflight";
 import { logClientSystemEvent } from "../../../lib/system-log";
@@ -195,56 +195,61 @@ export function ColanderApp() {
     setActiveAction(null);
     setStatus(`Reading ${short(kt)}…`);
     try {
-      const tezos = await colanderGetTezos();
-      const contract = await tezos.contract.at(kt);
-      const entrypoints = Object.keys((contract as any).entrypoints?.entrypoints ?? {});
-      const adapter = detectPastaContract(entrypoints);
-      const actions = adapter ? availableActions(adapter, entrypoints) : [];
+      const readContract = async (tezos: any): Promise<OpenedContract> => {
+        const contract = await tezos.contract.at(kt);
+        const entrypoints = Object.keys((contract as any).entrypoints?.entrypoints ?? {});
+        const adapter = detectPastaContract(entrypoints);
+        const actions = adapter ? availableActions(adapter, entrypoints) : [];
 
-      let admin: string | undefined;
-      let pendingAdmin: string | undefined;
-      let tokenCount: number | undefined;
-      let revisionCount: number | undefined;
-      let relationship: OwnershipRelationshipMetadata | undefined;
-      let metadataUri: string | undefined;
-      try {
-        const st: any = await contract.storage();
-        admin = typeof st.administrator === "string" ? st.administrator : undefined;
-        pendingAdmin =
-          st.pending_administrator && typeof st.pending_administrator === "string"
-            ? st.pending_administrator
-            : undefined;
-        tokenCount = bigToNum(st.next_token_id);
-        revisionCount = bigToNum(st.revision_count);
-        if (st.metadata && typeof st.metadata.get === "function") {
-          const raw = await st.metadata.get("");
-          if (typeof raw === "string" && raw.length > 0) {
-            metadataUri = hexToUtf8(raw);
-            relationship = await fetchRelationship(metadataUri);
+        let admin: string | undefined;
+        let pendingAdmin: string | undefined;
+        let tokenCount: number | undefined;
+        let revisionCount: number | undefined;
+        let relationship: OwnershipRelationshipMetadata | undefined;
+        let metadataUri: string | undefined;
+        try {
+          const st: any = await contract.storage();
+          admin = typeof st.administrator === "string" ? st.administrator : undefined;
+          pendingAdmin =
+            st.pending_administrator && typeof st.pending_administrator === "string"
+              ? st.pending_administrator
+              : undefined;
+          tokenCount = bigToNum(st.next_token_id);
+          revisionCount = bigToNum(st.revision_count);
+          if (st.metadata && typeof st.metadata.get === "function") {
+            const raw = await st.metadata.get("");
+            if (typeof raw === "string" && raw.length > 0) {
+              metadataUri = hexToUtf8(raw);
+              relationship = await fetchRelationship(metadataUri);
+            }
           }
+        } catch {
+          // storage shape varies; the control panel still works from entrypoints alone.
         }
-      } catch {
-        // storage shape varies; the control panel still works from entrypoints alone.
-      }
 
-      const next: OpenedContract = {
-        address: kt,
-        adapter,
-        entrypoints,
-        actions,
-        admin,
-        pendingAdmin,
-        tokenCount,
-        revisionCount,
-        relationship,
-        metadataUri,
+        return {
+          address: kt,
+          adapter,
+          entrypoints,
+          actions,
+          admin,
+          pendingAdmin,
+          tokenCount,
+          revisionCount,
+          relationship,
+          metadataUri,
+        };
       };
+
+      const next = getColanderTezosHarness()?.getTezos
+        ? await readContract(await colanderGetTezos())
+        : await withTezosRpcFallback((tezos) => readContract(tezos), { network, attemptTimeoutMs: 10_000 });
       setOpened(next);
-      setStatus(adapter ? `Opened ${adapter.label}` : "Opened (unrecognized contract)");
+      setStatus(next.adapter ? `Opened ${next.adapter.label}` : "Opened (unrecognized contract)");
       logClientSystemEvent({
         eventType: "colander.contract_opened",
         message: `Colander opened ${kt}`,
-        metadata: { app: "Colander", contract: kt, kind: adapter?.kind ?? "unknown", network },
+        metadata: { app: "Colander", contract: kt, kind: next.adapter?.kind ?? "unknown", network },
       });
       logClientSystemEvent({
         eventType: "colander.graph_viewed",
@@ -252,8 +257,8 @@ export function ColanderApp() {
         metadata: {
           app: "Colander",
           contract: kt,
-          hasRelationship: Boolean(relationship),
-          franchise: relationship?.franchise_contract ?? null,
+          hasRelationship: Boolean(next.relationship),
+          franchise: next.relationship?.franchise_contract ?? null,
         },
       });
     } catch (e) {

--- a/client/src/lib/tezos/loaders.ts
+++ b/client/src/lib/tezos/loaders.ts
@@ -1,4 +1,4 @@
-import { RPC_URLS } from "@shared/types";
+import { RPC_FALLBACK_URLS, RPC_URLS } from "@shared/types";
 
 function viteEnv(name: string): string | undefined {
   const raw = (import.meta as any).env?.[name];
@@ -15,6 +15,19 @@ export function getRpcUrlForNetwork(network: string): string {
   const envRpcUrl = viteEnv("VITE_TEZOS_RPC_URL");
   if (envRpcUrl && network === envNetwork) return envRpcUrl;
   return RPC_URLS[network] || RPC_URLS.mainnet;
+}
+
+function normalizeRpcUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function getRpcFallbackUrlsForNetwork(network: string): string[] {
+  const envNetwork = viteEnv("VITE_TEZOS_NETWORK") || "mainnet";
+  const envRpcUrl = viteEnv("VITE_TEZOS_RPC_URL");
+  if (envRpcUrl && network === envNetwork) return [];
+
+  const primary = normalizeRpcUrl(getRpcUrlForNetwork(network));
+  return (RPC_FALLBACK_URLS[network] || []).filter((url) => normalizeRpcUrl(url) !== primary);
 }
 
 export function getNetwork(): string {

--- a/client/src/lib/tezos/wallet-shadownet-preflight-policy.test.ts
+++ b/client/src/lib/tezos/wallet-shadownet-preflight-policy.test.ts
@@ -4,11 +4,16 @@ import test from "node:test";
 
 const preflight = readFileSync(new URL("./preflight.ts", import.meta.url), "utf8");
 const loaders = readFileSync(new URL("./loaders.ts", import.meta.url), "utf8");
+const wallet = readFileSync(new URL("./wallet.ts", import.meta.url), "utf8");
 const marketplace = readFileSync(new URL("./marketplace.ts", import.meta.url), "utf8");
 const inAppMarket = readFileSync(new URL("./in-app-market.ts", import.meta.url), "utf8");
 const token = readFileSync(new URL("./token.ts", import.meta.url), "utf8");
 const wtfToken = readFileSync(new URL("./wtf-token.ts", import.meta.url), "utf8");
 const sharedTypes = readFileSync(new URL("../../../../shared/types.ts", import.meta.url), "utf8");
+const colander = readFileSync(
+  new URL("../../features/pasta-protocol/colander/ColanderApp.tsx", import.meta.url),
+  "utf8"
+);
 const inAppMarketSync = readFileSync(
   new URL("../../../../server/lib/in-app-market-sync.ts", import.meta.url),
   "utf8"
@@ -23,6 +28,23 @@ test("Shadownet marketplace sends use explicit RPC and chain-id preflight", () =
   assert.match(loaders, /localStorage\.getItem\("wtf:network"\)/);
   assert.match(preflight, /NetXsqzbfFenSTS:\s*"shadownet"/);
   assert.match(preflight, /shadownet:\s*"NetXsqzbfFenSTS"/);
+});
+
+test("Shadownet Colander reads can fail over to the configured project RPC fallback", () => {
+  assert.match(sharedTypes, /RPC_FALLBACK_URLS/);
+  assert.match(sharedTypes, /shadownet:\s*\["https:\/\/tcinfra\.net\/rpc\/tezos\/shadownet"\]/);
+  assert.match(loaders, /getRpcFallbackUrlsForNetwork/);
+  assert.match(loaders, /VITE_TEZOS_RPC_URL/);
+  assert.match(loaders, /if \(envRpcUrl && network === envNetwork\) return \[\]/);
+  assert.match(wallet, /withTezosRpcFallback/);
+  assert.match(wallet, /getRpcFallbackUrlsForNetwork\(config\.network\)/);
+  assert.match(wallet, /isRecoverableRpcError/);
+  assert.match(wallet, /http request timeout/);
+  assert.match(wallet, /withRpcAttemptTimeout/);
+  assert.match(wallet, /attemptTimeoutMs/);
+  assert.match(colander, /withTezosRpcFallback/);
+  assert.match(colander, /attemptTimeoutMs:\s*10_000/);
+  assert.match(colander, /getColanderTezosHarness\(\)\?\.getTezos/);
 });
 
 test("Shadownet marketplace flows use the configured WTF FA2 token", () => {

--- a/client/src/lib/tezos/wallet.ts
+++ b/client/src/lib/tezos/wallet.ts
@@ -1,6 +1,7 @@
 import {
   loadOctezConnect,
   loadTaquito,
+  getRpcFallbackUrlsForNetwork,
   getRpcUrlForNetwork,
   getNetwork,
 } from "./loaders";
@@ -124,6 +125,43 @@ function resolveAuthWalletConfig(): WalletNetworkConfig {
 
 function sameWalletConfig(a: WalletNetworkConfig | null, b: WalletNetworkConfig): boolean {
   return !!a && a.network === b.network && a.rpcUrl === b.rpcUrl;
+}
+
+function normalizeRpcUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function uniqueRpcUrls(urls: string[]): string[] {
+  const seen = new Set<string>();
+  return urls.filter((url) => {
+    const normalized = normalizeRpcUrl(url);
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function isRecoverableRpcError(err: unknown): boolean {
+  const message = String((err as Error)?.message || (err as Error)?.name || err || "").toLowerCase();
+  return /access-control|cors|failed to fetch|http request timeout|networkerror|rpc|timeout|503|502|504/.test(message);
+}
+
+async function withRpcAttemptTimeout<T>(task: Promise<T>, rpcUrl: string, timeoutMs?: number): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return task;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Tezos RPC attempt timed out after ${timeoutMs}ms at ${rpcUrl}`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 interface WalletAdapter {
@@ -578,6 +616,34 @@ export async function getTezos(options: { network?: string; rpcUrl?: string } = 
     await currentAdapter.setAsTaquitoProvider(tezosToolkit);
   }
   return tezosToolkit;
+}
+
+export async function withTezosRpcFallback<T>(
+  task: (tezos: any, context: { network: string; rpcUrl: string; attempt: number }) => Promise<T>,
+  options: { network?: string; rpcUrl?: string; attemptTimeoutMs?: number } = {},
+): Promise<T> {
+  const config = resolveWalletConfig(options);
+  const fallbackUrls = options.rpcUrl ? [] : getRpcFallbackUrlsForNetwork(config.network);
+  const candidates = uniqueRpcUrls([config.rpcUrl, ...fallbackUrls]);
+  let lastError: unknown;
+
+  for (let index = 0; index < candidates.length; index += 1) {
+    const rpcUrl = candidates[index];
+    try {
+      const tezos = await getTezos({ network: config.network, rpcUrl });
+      return await withRpcAttemptTimeout(
+        task(tezos, { network: config.network, rpcUrl, attempt: index + 1 }),
+        rpcUrl,
+        options.attemptTimeoutMs,
+      );
+    } catch (err) {
+      lastError = err;
+      if (index >= candidates.length - 1 || !isRecoverableRpcError(err)) throw err;
+      console.warn(`[WTF] Tezos RPC ${rpcUrl} failed; retrying with fallback ${candidates[index + 1]}`, err);
+    }
+  }
+
+  throw lastError;
 }
 
 async function activateAdapterForSend(

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -894,6 +894,12 @@ export const RPC_URLS: Record<string, string> = {
   shadownet: "https://tezos-shadownet.octez.io/",
 };
 
+export const RPC_FALLBACK_URLS: Record<string, string[]> = {
+  mainnet: ["https://tcinfra.net/rpc/tezos/mainnet"],
+  ghostnet: [],
+  shadownet: ["https://tcinfra.net/rpc/tezos/shadownet"],
+};
+
 // ---------------------------------------------------------------------------
 // SpicySwap DEX constants & types
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds configured Tezos RPC fallback metadata for browser clients.
- Routes Colander read-only Shadownet contract discovery through recoverable RPC fallback with a bounded 10s per-attempt read budget.
- Preserves explicit VITE_TEZOS_RPC_URL overrides and the localhost Colander wallet-action harness.
- Records WTF-BB-347 and the lessons-learned entry for the broad-suite timeout root cause.

## Verification
- npx tsx --test client/src/lib/tezos/wallet-shadownet-preflight-policy.test.ts client/src/lib/tezos/wallet-connect-policy.test.ts
- npm run check -- --pretty false
- npm run build && HARNESS_PORT=4322 npx playwright test tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs --project=chromium --reporter=list
- npx playwright test tests/playwright/inventory/auth-session.spec.mjs tests/playwright/inventory/beta-wtfos.spec.mjs tests/playwright/inventory/broot.spec.mjs tests/playwright/inventory/cobwebsaints-account.spec.mjs tests/playwright/inventory/dedrooms.spec.mjs tests/playwright/inventory/desktop-settings-typography.spec.mjs tests/playwright/inventory/domain-interoperability.spec.mjs tests/playwright/inventory/feature-depth.spec.mjs tests/playwright/inventory/gamma-wtfos.spec.mjs tests/playwright/inventory/ipfs-pinning-manager.spec.mjs tests/playwright/inventory/macaroni-packager.spec.mjs tests/playwright/inventory/map-lab-workspace.spec.mjs tests/playwright/inventory/market-pricing.spec.mjs tests/playwright/inventory/pasta-protocol-colander-shadownet.spec.mjs --project=chromium --reporter=list
- npm run test:e2e:inventory:coverage
- npm run pasta:repo-cleanup:audit:check
- npm run pasta:live-readiness:check
- npm run pasta:repo-cleanup:audit
- PASTA_LIVE_READINESS_ALLOW_BLOCKERS=1 npm run pasta:live-readiness
- git diff --check

## Remaining Live Blockers
- Pasta final launch is still blocked on dedicated WTF.ME publish credentials.
- Pasta final launch is still blocked on a live Pasta WTF.ME host serving the landing/mint/collection pages and pin discovery.
